### PR TITLE
Truncate Excel flat text to configurable limit

### DIFF
--- a/generate_from_image.py
+++ b/generate_from_image.py
@@ -24,6 +24,8 @@ from core.generate_video import generate_video_for_paragraphs
 from core.excel_utils import extract_sheet_text
 
 
+EXCEL_FLAT_TEXT_LIMIT = int(os.getenv("EXCEL_FLAT_TEXT_LIMIT", "5000"))
+
 def read_prompt_template() -> str:
     """Read the base prompt for image-only transcription."""
     path = os.path.join("prompt_library", "EGM_Help_image_to_audio.txt")
@@ -114,6 +116,11 @@ def main(
             "sheet_name": excel_data["sheet_name"],
             "flat_text": excel_data["flat_text"],
         }
+        if len(excel_payload["flat_text"]) > EXCEL_FLAT_TEXT_LIMIT:
+            debug_print(
+                f"Truncating Excel flat_text from {len(excel_payload['flat_text'])} to {EXCEL_FLAT_TEXT_LIMIT} characters."
+            )
+            excel_payload["flat_text"] = excel_payload["flat_text"][:EXCEL_FLAT_TEXT_LIMIT]
         excel_markdown = excel_data.get("markdown", "")
         # Save the markdown as a .md file in output/prompts for auditing
         excel_markdown_output = os.path.join("output", "prompts", today_date_folder, f"excel_markdown_{_sanitize_name(os.path.splitext(os.path.basename(excel_path))[0])}_{_sanitize_name(sheet_name)}.md")

--- a/rules.txt
+++ b/rules.txt
@@ -1,0 +1,2 @@
+Excel flat_text is truncated to 5,000 characters by default.
+Set EXCEL_FLAT_TEXT_LIMIT to change this limit.


### PR DESCRIPTION
## Summary
- Add `EXCEL_FLAT_TEXT_LIMIT` to cap Excel-derived flat text to 5k characters by default
- Log whenever the Excel flat text is truncated before prompting
- Document the new limit and environment variable in `rules.txt`

## Testing
- `python -m py_compile generate_from_image.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c697135ba8832d9d17412437c48452