### PR TITLE
Add PDF layout note to prompt template

### DIFF
--- a/prompt_library/prompt_template.txt
+++ b/prompt_library/prompt_template.txt
@@ -72,6 +72,7 @@ Keep text_to_be_rendered short, punchy, and easily readable on a vertical video 
 audio_script can be longer, conversational, and may repeat or expand on screen text.
 tts fields are optional defaults for OpenAI Speech; leave them as provided placeholders unless other values are passed (e.g., different voice, rate, pitch).
 Omit any element you cannot extract gracefully.
+When a PDF is attached, rely on its visual layout for structure. Merged cells indicate headers spanning multiple columns; treat them as section titles and use the layout for implied hierarchy.
 
 ## Example invocation
 RULE_DATA = {


### PR DESCRIPTION
## Summary
- In prompt template, advise model to reference PDF layout when interpreting merged cells and hierarchy.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c696ff7680832db49255b54f60ed7e