### PR TITLE
fix: correct JSON placeholder in help template

### DIFF
--- a/prompt_library/EGM_Help_excel_image_to_audio.txt
+++ b/prompt_library/EGM_Help_excel_image_to_audio.txt
@@ -21,7 +21,7 @@ Casino players reading help screens and the machine’s voice-over. Output is co
 * Shape:
 
 ```json
-<<EXCEL_DATA_MARKDOWN>>
+<<EXCEL_DATA_JSON>>
 ```
 
 1b. **Excel-derived Markdown table (exact grid)**


### PR DESCRIPTION
## Summary
- fix Excel help template to show JSON placeholder instead of markdown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c696fe1efc832da2de65be6c4b2bf2