### PR TITLE
Add wrapper for image-based OpenAI invocation

### DIFF
--- a/core/invoke_openai_with_image.py
+++ b/core/invoke_openai_with_image.py
@@ -1,0 +1,18 @@
+"""Compatibility wrapper for image-based OpenAI invocation.
+
+This module exposes a thin proxy around
+``generate_script_json.invoke_openai_with_image`` so that other modules can
+import it from ``core.invoke_openai_with_image`` without referencing the
+larger script generation module directly.
+"""
+
+from .generate_script_json import invoke_openai_with_image as _invoke
+
+
+def invoke_openai_with_image(prompt: str, image_path: str, temperature: float = 0):
+    """Invoke OpenAI with a prompt and image.
+
+    This function forwards its arguments to
+    :func:`core.generate_script_json.invoke_openai_with_image`.
+    """
+    return _invoke(prompt, image_path, temperature=temperature)


### PR DESCRIPTION
## Summary
- expose invoke_openai_with_image through dedicated wrapper module

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c696fafac8832d8c7493006195c44b