### PR TITLE
Add pdfkit dependency and document wkhtmltopdf installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Marketing Tool
+
+This project uses `pdfkit` to convert HTML content into PDF files. It relies on the external `wkhtmltopdf` binary.
+
+## Installation
+
+1. Install Python dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Install the `wkhtmltopdf` command-line tool:
+
+   - **Ubuntu/Debian**:
+     ```bash
+     sudo apt-get install wkhtmltopdf
+     ```
+   - **macOS** (Homebrew):
+     ```bash
+     brew install wkhtmltopdf
+     ```
+
+Ensure `wkhtmltopdf` is available on your `PATH` before running the application.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 pandas
 openpyxl
 xlrd
+pdfkit


### PR DESCRIPTION
## Summary
- add `pdfkit` for HTML-to-PDF conversion
- document `wkhtmltopdf` binary installation requirements

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68c696f9446c832db93d41f6d57c419b