### PR TITLE
Add PDF encoding support tests for OpenAI payload

### DIFF
--- a/core/generate_script_json.py
+++ b/core/generate_script_json.py
@@ -93,3 +93,69 @@ def invoke_openai_with_image(prompt, image_path, temperature=0):
     )
 
     return response.choices[0].message.content
+
+
+def invoke_openai_with_image_and_pdf(prompt, image_path, pdf_path, temperature=0):
+    """Invoke OpenAI with a prompt, an image, and a PDF document.
+
+    This helper mirrors :func:`invoke_openai_with_image` but includes an
+    additional PDF payload encoded in base64.  The PDF is attached using the
+    ``input_pdf`` type which is accepted by Azure OpenAI for multimodal
+    requests.  The function returns the string content from the first choice of
+    the response.
+
+    Parameters
+    ----------
+    prompt : str
+        Text prompt sent to the model.
+    image_path : str
+        Path to an image that will be base64 encoded and attached.
+    pdf_path : str
+        Path to a PDF file that will be base64 encoded and attached.
+    temperature : float, optional
+        Sampling temperature, by default 0.
+    """
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    api_base = os.getenv("OPENAI_API_BASE")
+    api_version = os.getenv("OPENAI_API_VERSION")
+    model = os.getenv("OPENAI_DEPLOYMENT_NAME")
+
+    if not all([api_key, api_base, api_version, model]):
+        raise RuntimeError(
+            "Please set OPENAI_API_KEY, OPENAI_API_BASE, OPENAI_API_VERSION, and OPENAI_DEPLOYMENT_NAME"
+        )
+
+    client = AzureOpenAI(
+        api_key=api_key,
+        api_version=api_version,
+        azure_endpoint=api_base,
+    )
+
+    # Encode image and PDF as base64 strings
+    with open(image_path, "rb") as f:
+        img_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    with open(pdf_path, "rb") as f:
+        pdf_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    input_payload = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{img_b64}"},
+                },
+                {
+                    "type": "input_pdf",
+                    "data": pdf_b64,
+                    "mime_type": "application/pdf",
+                },
+            ],
+        }
+    ]
+
+    response = client.chat.completions.create(model=model, messages=input_payload)
+    return response.choices[0].message.content

--- a/tests/test_excel_pdf.py
+++ b/tests/test_excel_pdf.py
@@ -1,0 +1,121 @@
+import base64
+import os
+import sys
+from io import BytesIO
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+
+# Ensure repository root on path for module imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.generate_script_json import invoke_openai_with_image_and_pdf
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities for tests
+# ---------------------------------------------------------------------------
+
+def _sheet_to_pdf(sheet, pdf_path: str) -> None:
+    """Write the contents of an ``openpyxl`` sheet to a minimal PDF file."""
+    lines = []
+    for row in sheet.iter_rows(values_only=True):
+        line = ",".join("" if cell is None else str(cell) for cell in row)
+        lines.append(line)
+    text = "\n".join(lines)
+    pdf_content = f"%PDF-1.4\n{text}\n%%EOF".encode("utf-8")
+    with open(pdf_path, "wb") as f:
+        f.write(pdf_content)
+
+
+def _create_tiny_png(path: str) -> None:
+    """Create a 1x1 white PNG without requiring Pillow."""
+    tiny_png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+    )
+    with open(path, "wb") as f:
+        f.write(tiny_png)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_export_excel_sheet_to_pdf(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws["A1"] = "Hello"
+    ws["B1"] = "World"
+
+    buf = BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    loaded = load_workbook(buf)
+    sheet = loaded.active
+
+    pdf_path = tmp_path / "sheet.pdf"
+    _sheet_to_pdf(sheet, str(pdf_path))
+
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size > 0
+
+
+def test_invoke_openai_with_image_and_pdf_encodes_files(monkeypatch, tmp_path):
+    image_path = tmp_path / "img.png"
+    _create_tiny_png(str(image_path))
+
+    # Reuse PDF creation from previous test
+    wb = Workbook()
+    ws = wb.active
+    ws["A1"] = "One"
+    buf = BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    sheet = load_workbook(buf).active
+    pdf_path = tmp_path / "sheet.pdf"
+    _sheet_to_pdf(sheet, str(pdf_path))
+
+    # Set required environment variables
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://example.org")
+    monkeypatch.setenv("OPENAI_API_VERSION", "2024-05-01")
+    monkeypatch.setenv("OPENAI_DEPLOYMENT_NAME", "model")
+
+    captured = {}
+
+    class DummyCompletions:
+        def create(self, *, model, messages):
+            captured["model"] = model
+            captured["messages"] = messages
+
+            class Resp:
+                choices = [
+                    type("Obj", (), {"message": type("Obj", (), {"content": "ok"})()})
+                ]
+
+            return Resp()
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            self.chat = type("Obj", (), {"completions": DummyCompletions()})()
+
+    monkeypatch.setattr(
+        "core.generate_script_json.AzureOpenAI", lambda **kwargs: DummyClient()
+    )
+
+    result = invoke_openai_with_image_and_pdf("hi", str(image_path), str(pdf_path))
+    assert result == "ok"
+
+    messages = captured["messages"]
+    assert isinstance(messages, list) and messages
+    content = messages[0]["content"]
+    types = [part["type"] for part in content]
+    assert "image_url" in types
+    assert "input_pdf" in types
+
+    img_part = next(part for part in content if part["type"] == "image_url")
+    assert img_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+    pdf_part = next(part for part in content if part["type"] == "input_pdf")
+    assert pdf_part["data"]
+    assert pdf_part["mime_type"] == "application/pdf"


### PR DESCRIPTION
## Summary
- extend `invoke_openai_with_image_and_pdf` to send both image and PDF attachments
- add tests for exporting Excel sheets to PDF and verifying PDF+image payload encoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c696f7d5dc832da5a392c293849b39