### PR TITLE
Validate prompt placeholders and fix language templates

### DIFF
--- a/generate_from_image.py
+++ b/generate_from_image.py
@@ -41,7 +41,10 @@ def read_prompt_template_excel_image() -> str:
 def prepare_prompt(language: str = "english") -> str:
     """Prepare the prompt for image-only mode."""
     prompt = read_prompt_template()
-    return prompt.replace("<<LANGUAGE>>", language)
+    prompt = prompt.replace("<<LANGUAGE>>", language)
+    if "<<LANGUAGE>>" in prompt:
+        raise ValueError("Unresolved placeholder <<LANGUAGE>> in prompt")
+    return prompt
 
 
 def prepare_prompt_excel_image(language: str, excel_data_json: str, excel_data_markdown: str) -> str:
@@ -59,6 +62,10 @@ def prepare_prompt_excel_image(language: str, excel_data_json: str, excel_data_m
     else:
         # Append a clearly labeled Markdown section so the model sees the exact grid.
         prompt += "\n\n## Excel-Derived Markdown (authoritative table)\n\n```markdown\n" + excel_data_markdown + "\n```\n"
+
+    if "<<LANGUAGE>>" in prompt or "<<EXCEL_DATA_JSON>>" in prompt:
+        raise ValueError("Unresolved placeholders in prompt")
+
     return prompt
 
 

--- a/prompt_library/EGM_Help_excel_image_to_audio.txt
+++ b/prompt_library/EGM_Help_excel_image_to_audio.txt
@@ -3,7 +3,7 @@
 
 ## Role
 
-You are a precise <<language>>>> **content assembler** for casino Electronic Gaming Machine (EGM) help screens.
+You are a precise <<LANGUAGE>> **content assembler** for casino Electronic Gaming Machine (EGM) help screens.
 
 ## Purpose
 
@@ -21,7 +21,7 @@ Casino players reading help screens and the machine’s voice-over. Output is co
 * Shape:
 
 ```json
-<<EXCEL_DATA_MARKDOWN>>
+<<EXCEL_DATA_JSON>>
 ```
 
 1b. **Excel-derived Markdown table (exact grid)**

--- a/prompt_library/EGM_Help_image_to_audio.txt
+++ b/prompt_library/EGM_Help_image_to_audio.txt
@@ -35,17 +35,17 @@ Return **only** the following JSON object:
     {
       "paragraph_number": 1,
       "text_to_be_rendered": "<short on-screen caption, ≤12 words>",
-      "audio_script": "<exact text from image, with symbols spoken in <<LANGUAGE>>>"
+      "audio_script": "<exact text from image, with symbols spoken in <<LANGUAGE>>"
     },
     {
       "paragraph_number": 2,
       "text_to_be_rendered": "<short on-screen caption, ≤12 words>",
-      "audio_script": "<exact text from image, with symbols spoken in <<LANGUAGE>>>"
+      "audio_script": "<exact text from image, with symbols spoken in <<LANGUAGE>>"
     },
     {
       "paragraph_number": 3,
       "text_to_be_rendered": "<short on-screen caption, ≤12 words>",
-      "audio_script": "<exact text from image, with symbols spoken in <<LANGUAGE>>>"
+      "audio_script": "<exact text from image, with symbols spoken in <<LANGUAGE>>"
     }
   ],
   "raw_text": "<full plain-text transcription preserving line breaks>"


### PR DESCRIPTION
## Summary
- guard against unresolved placeholders in `prepare_prompt` and `prepare_prompt_excel_image`
- tidy EGM help templates by fixing `<<LANGUAGE>>` tokens and JSON placeholder

## Testing
- `python -m py_compile generate_from_image.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c696f42704832db9a46b51a898130a