### PR TITLE
refactor: drop markdown from excel prompt

### DIFF
--- a/generate_from_image.py
+++ b/generate_from_image.py
@@ -44,21 +44,11 @@ def prepare_prompt(language: str = "english") -> str:
     return prompt.replace("<<LANGUAGE>>", language)
 
 
-def prepare_prompt_excel_image(language: str, excel_data_json: str, excel_data_markdown: str) -> str:
-    """Prepare the prompt for Excel+image mode with embedded authoritative Excel JSON and Markdown table.
-
-    If the template contains a placeholder `<<EXCEL_DATA_MARKDOWN>>`, it will be replaced.
-    Otherwise, a new Markdown section is appended to the end of the prompt.
-    """
+def prepare_prompt_excel_image(language: str, excel_data_json: str) -> str:
+    """Prepare the prompt for Excel+image mode with embedded authoritative Excel JSON."""
     prompt = read_prompt_template_excel_image()
     prompt = prompt.replace("<<LANGUAGE>>", language)
     prompt = prompt.replace("<<EXCEL_DATA_JSON>>", excel_data_json)
-
-    if "<<EXCEL_DATA_MARKDOWN>>" in prompt:
-        prompt = prompt.replace("<<EXCEL_DATA_MARKDOWN>>", excel_data_markdown)
-    else:
-        # Append a clearly labeled Markdown section so the model sees the exact grid.
-        prompt += "\n\n## Excel-Derived Markdown (authoritative table)\n\n```markdown\n" + excel_data_markdown + "\n```\n"
     return prompt
 
 
@@ -114,14 +104,9 @@ def main(
             "sheet_name": excel_data["sheet_name"],
             "flat_text": excel_data["flat_text"],
         }
-        excel_markdown = excel_data.get("markdown", "")
-        # Save the markdown as a .md file in output/prompts for auditing
-        excel_markdown_output = os.path.join("output", "prompts", today_date_folder, f"excel_markdown_{_sanitize_name(os.path.splitext(os.path.basename(excel_path))[0])}_{_sanitize_name(sheet_name)}.md")
-        _save_text(excel_markdown_output, excel_markdown)
         prompt = prepare_prompt_excel_image(
             language=language,
             excel_data_json=json.dumps(excel_payload, ensure_ascii=False, indent=2),
-            excel_data_markdown=excel_markdown,
         )
         suffix = f"{_sanitize_name(os.path.splitext(os.path.basename(excel_path))[0])}_{_sanitize_name(sheet_name)}"
         # Save prompt for audit in all cases

--- a/prompt_library/EGM_Help_excel_image_to_audio.txt
+++ b/prompt_library/EGM_Help_excel_image_to_audio.txt
@@ -3,7 +3,7 @@
 
 ## Role
 
-You are a precise <<language>>>> **content assembler** for casino Electronic Gaming Machine (EGM) help screens.
+You are a precise <<LANGUAGE>> **content assembler** for casino Electronic Gaming Machine (EGM) help screens.
 
 ## Purpose
 
@@ -16,18 +16,12 @@ Casino players reading help screens and the machine’s voice-over. Output is co
 ## Inputs
 
 1. **Excel-derived JSON (authoritative source)**
-
-* Variable name: `EXCEL_DATA`
-* Shape:
+   * The authoritative Excel sheet is supplied as an attached PDF; reference it when assembling paragraphs.
+   * Variable name: `EXCEL_DATA`
+   * Shape:
 
 ```json
-<<EXCEL_DATA_MARKDOWN>>
-```
-
-1b. **Excel-derived Markdown table (exact grid)**
-
-```markdown
-<<EXCEL_DATA_MARKDOWN>>
+<<EXCEL_DATA_JSON>>
 ```
 
 


### PR DESCRIPTION
## Summary
- clarify EGM help prompt: fix `<<LANGUAGE>>` typo, switch to `<<EXCEL_DATA_JSON>>`, and note authoritative Excel PDF
- strip Markdown handling from Excel+image prompt builder

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c696efaa58832db05acf5313b29afd