### PR TITLE
Add Excel sheet PDF export and drop markdown usage

### DIFF
--- a/core/excel_utils.py
+++ b/core/excel_utils.py
@@ -233,3 +233,38 @@ def extract_sheet_text(excel_path: str, sheet_name: str) -> Dict[str, Any]:
         "flat_text": flat,
         "markdown": markdown,
     }
+
+
+def export_sheet_pdf(excel_path: str, sheet_name: str, output_pdf: str) -> str:
+    """Render an Excel sheet to PDF.
+
+    This helper reads the specified sheet into a DataFrame, converts it to
+    HTML, and then writes that HTML to a PDF file. The output directory is
+    created if it does not already exist.
+
+    Returns the path to the generated PDF.
+    """
+    import pandas as pd
+    import os
+
+    # Read the sheet using the appropriate engine
+    engine = _engine_for_excel(excel_path)
+    df = pd.read_excel(excel_path, sheet_name=sheet_name, engine=engine)
+
+    # Convert DataFrame to HTML
+    html = df.to_html(index=False)
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(output_pdf) or ".", exist_ok=True)
+
+    # Attempt to convert HTML to PDF using pdfkit or weasyprint
+    try:
+        import pdfkit
+
+        pdfkit.from_string(html, output_pdf)
+    except Exception:
+        from weasyprint import HTML  # type: ignore
+
+        HTML(string=html).write_pdf(output_pdf)
+
+    return output_pdf


### PR DESCRIPTION
## Summary
- add `export_sheet_pdf` helper to render Excel sheets as PDFs
- generate prompts using PDF export instead of markdown tables

## Testing
- `python -m py_compile core/excel_utils.py generate_from_image.py`


------
https://chatgpt.com/codex/tasks/task_b_68c696e27608832d9a5a68d261b87b4e